### PR TITLE
Changed brand colors of Google and Microsoft

### DIFF
--- a/template/src/data/auth-providers.js
+++ b/template/src/data/auth-providers.js
@@ -30,13 +30,13 @@ const authProviders = [
   },
   {
     id: "google.com",
-    color: "#4285f4",
+    color: "#DB4437",
     icon: <GoogleIcon />,
     name: "Google",
   },
   {
     id: "microsoft.com",
-    color: "#f65314",
+    color: "#0078d7",
     icon: <MicrosoftIcon />,
     name: "Microsoft",
   },


### PR DESCRIPTION
Google is being represented as blue and Microsoft as orange.

Better suiting colors could be:
Google - red-ish (Google+)
Microsoft - dark blue (Windows default)